### PR TITLE
New command instances

### DIFF
--- a/src/clom/command.py
+++ b/src/clom/command.py
@@ -499,6 +499,9 @@ class Command(Operation):
         """
         self._redirects[arg.STDIN] = ('<', filename)
 
+    def new(self):
+        return Command(self._clom, self.name)
+
     def _clone(self):
         q = super(Command, self)._clone()
         q._args = self._args[:]

--- a/src/tests/test_clom.py
+++ b/src/tests/test_clom.py
@@ -42,3 +42,20 @@ def test_shell():
             assert line == 'b'
         else:
             assert line == 'c'    
+
+def test_new_commands():
+    """
+    Verify that you can manually re-create a command instead of cloning it.
+    """
+    ls_cmd_a = clom.ls.new().with_opts('-r')
+    ls_cmd_b = clom.ls.new().with_opts('-lah')
+    assert str(ls_cmd_a) != str(ls_cmd_b)
+
+    ls_cmd_x = clom.ls.with_env(foo='monkey')
+    ls_cmd_y = clom.ls.new()
+    assert str(ls_cmd_x) != str(ls_cmd_y)
+
+    ls_cmd_m = clom.ls.with_env(bar='gorilla')
+    ls_cmd_n = clom.ls
+    assert str(ls_cmd_m) == str(ls_cmd_n)
+    


### PR DESCRIPTION
I ran into a case where having the commands clone automatically was breaking things for me and I hadn't expected it. When writing other unit tests, some environmental stuff for one command was persisting into another test.

The `new()` method doesn't really jive with the cloning mentality of clom, but I couldn't think of a better way since I think the existing implicit clone is preferred.

Tests included and everything passes.
