### PR TITLE
Making piping clom commands work better by also passing along the piped commands

### DIFF
--- a/src/clom/command.py
+++ b/src/clom/command.py
@@ -36,7 +36,7 @@ class Operation(object):
     """
 
     def __init__(self):
-        self._pipe_to = None
+        self._pipe_to = []
         self._redirects = {}
         self._env = {}
         self._background = False
@@ -78,7 +78,7 @@ class Operation(object):
             'ls | grep'
 
         """
-        self._pipe_to = to_cmd
+        self._pipe_to.append(to_cmd)
 
     @_makes_clone
     def append_to_file(self, filename, fd=arg.STDOUT):
@@ -225,9 +225,9 @@ class Operation(object):
                 s.append('%s%s' % (fd, dir))
                 s.append(self._escape_arg(output))
 
-        if self._pipe_to:
+        for c in self._pipe_to:
             s.append('|')
-            s.append(str(self._pipe_to))
+            s.append(str(c))
 
     def _build_command(self, s):
         raise NotImplemented('Must implement _build_command in base class')
@@ -504,6 +504,7 @@ class Command(Operation):
         q._args = self._args[:]
         q._listopts = self._listopts[:]
         q._kwopts = self._kwopts.copy()
+        q._pipe_to = self._pipe_to[:]
 
         return q
 

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -7,7 +7,7 @@ from clom import clom, STDERR, STDIN, STDOUT, NOTSET
 
 def monkeypatch_DoctestModule():
     """
-    Ugly monkeypath to make sure clom is available to all doctests when ran with py.test
+    Ugly monkeypatch to make sure clom is available to all doctests when ran with py.test
     """
     old_runtest = doctest.DoctestModule.runtest
 

--- a/src/tests/test_clom.py
+++ b/src/tests/test_clom.py
@@ -42,3 +42,20 @@ def test_shell():
             assert line == 'b'
         else:
             assert line == 'c'    
+
+def test_piping():
+    """
+    Verify that piping several commands together behaves as expected.
+    """
+    cmd_ls = clom.ls.with_opts('-lah')
+    cmd_ls._env = {}
+    cmd_echo = clom.echo.with_opts("monkey", "gorilla")
+    cmd_grep = clom.grep.with_opts('monkey')
+
+    ls_pipe_echo = cmd_ls.pipe_to(cmd_echo)
+    ls_pipe_echo_expected = 'ls -lah | echo monkey gorilla' 
+    assert ls_pipe_echo_expected == str(ls_pipe_echo)
+
+    ls_pipe_echo_pipe_grep = ls_pipe_echo.pipe_to(cmd_grep)
+    ls_pipe_echo_pipe_grep_expected = ls_pipe_echo_expected + ' | grep monkey'
+    assert ls_pipe_echo_pipe_grep_expected == str(ls_pipe_echo_pipe_grep)


### PR DESCRIPTION
...during cloning.

The tests show how I was expecting this to work. The real-world use case was chained together, something like this:

`clom.ls.with_opts('-lah').pipe_to(clom.echo.with_opts('monkey', 'gorilla')).pipe_to(clom.grep.with_opts('monkey')).shell().all()`

Let me know if I missed anything in the docs that makes this work like above. I saw the parent param, but it's never used.

You can also see in the tests a workaround for the other new commands pull request.
