### PR TITLE
clones should not share an env dict

### DIFF
--- a/src/clom/command.py
+++ b/src/clom/command.py
@@ -281,6 +281,7 @@ class Operation(object):
         q = cls.__new__(cls)
         q.__dict__ = self.__dict__.copy()
         q._redirects = self._redirects.copy()
+        q._env = self._env.copy()
 
         return q
 

--- a/src/tests/test_clom.py
+++ b/src/tests/test_clom.py
@@ -59,3 +59,15 @@ def test_piping():
     ls_pipe_echo_pipe_grep = ls_pipe_echo.pipe_to(cmd_grep)
     ls_pipe_echo_pipe_grep_expected = ls_pipe_echo_expected + ' | grep monkey'
     assert ls_pipe_echo_pipe_grep_expected == str(ls_pipe_echo_pipe_grep)
+
+def test_new_commands():
+    """
+    Verify that you can manually re-create a command instead of cloning it.
+    """
+    ls_cmd_a = clom.ls.with_opts('-r')
+    ls_cmd_b = clom.ls.with_opts('-lah')
+    assert str(ls_cmd_a) != str(ls_cmd_b)
+
+    ls_cmd_x = clom.ls.with_env(foo='monkey')
+    ls_cmd_y = clom.ls
+    assert str(ls_cmd_x) != str(ls_cmd_y)


### PR DESCRIPTION
This is similar to #2, but I think more correct.

Previously, cloned commands were sharing a single ._env attribute.
Classes' _clone methods should ensure that there's a copy made of any mutable attributes, and Operation wasn't doing this for its _env dict.
