### PR TITLE
Fix subcommand as argument. Make whitespace handling more rigorous.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ Group commands::
 	>>> OR(clom.vagrant.up, clom.echo('Vagrant up failed'))
 	'( vagrant up || echo 'Vagrant up failed' )'
 	>>> OR(clom.vagrant.up, clom.echo('Vagrant up failed')).shell()
-	<CommandResult return_code=0, stdout=17 bytes, stderr=... bytes>
+	<CommandResult return_code=0, stdout=18 bytes, stderr=... bytes>
 	>>> print(OR(clom.false, clom.echo('Vagrant up failed')).shell())
 	Vagrant up failed
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -77,7 +77,7 @@ Group commands::
 	>>> OR(clom.vagrant.up, clom.echo('Vagrant up failed'))
 	'( vagrant up || echo 'Vagrant up failed' )'
 	>>> OR(clom.vagrant.up, clom.echo('Vagrant up failed')).shell()
-	<CommandResult return_code=0, stdout=17 bytes, stderr=... bytes>
+	<CommandResult return_code=0, stdout=18 bytes, stderr=... bytes>
 	>>> print(OR(clom.false, clom.echo('Vagrant up failed')).shell())
 	Vagrant up failed
 

--- a/src/clom/command.py
+++ b/src/clom/command.py
@@ -208,7 +208,7 @@ class Operation(object):
 
     def _escape_arg(self, val):
         if isinstance(val, Command):
-            return '`%s`' % arg
+            return '"$(%s)"' % val
         elif isinstance(val, arg.BaseArg):
             return str(val)
         else:

--- a/src/tests/test_clom.py
+++ b/src/tests/test_clom.py
@@ -33,15 +33,18 @@ def test_shell():
     r = clom.echo.shell('')
     assert 0 == r.return_code
     assert r.return_code == r.code    
-    assert str(r) == r.stdout
+    assert str(r) == ''
+    assert r.stdout == '\n'
 
-    for i, line in enumerate(clom.echo.shell('a\nb\nc\n')):
+    for i, line in enumerate(clom.echo.shell('a\nb\nc')):
         if i == 0:
             assert line == 'a'
         elif i == 1:
             assert line == 'b'
-        else:
+        elif i == 2:
             assert line == 'c'    
+        else:
+            raise AssertionError('Did not expect line %i: %r' % (i, line))
 
 def test_piping():
     """
@@ -71,3 +74,14 @@ def test_new_commands():
     ls_cmd_x = clom.ls.with_env(foo='monkey')
     ls_cmd_y = clom.ls
     assert str(ls_cmd_x) != str(ls_cmd_y)
+
+def test_sub_command():
+    shell_stuff = r""" $`'" \ """
+    echo = clom.echo(shell_stuff)
+    assert str(echo) == r"""echo ' $`'\''" \ '"""
+    assert echo.shell() == shell_stuff
+
+    echo_twice = clom.echo(echo, shell_stuff)
+    assert str(echo_twice) == r"""echo "$(echo ' $`'\''" \ ')" ' $`'\''" \ '"""
+
+    assert str(echo_twice.shell()) == shell_stuff + ' ' + shell_stuff


### PR DESCRIPTION
The command-as-an-argument support was entirely broken, as far as I can see.
Testing it was tricky without fixing up whitespace handling.
The .stdout (and .stderr) property now contains the _exact_ contents retrieved from the subprocess.

Values returned from other methods are essentially unchanged.
