### PR TITLE
Pipe alias

### DIFF
--- a/src/clom/command.py
+++ b/src/clom/command.py
@@ -85,6 +85,9 @@ class Operation(object):
         """
         self._pipe_to.append(to_cmd)
 
+    # | is shorthand for pipe_to
+    __or__ = pipe_to
+
     @_makes_clone
     def append_to_file(self, filename, fd=arg.STDOUT):
         """

--- a/src/clom/command.py
+++ b/src/clom/command.py
@@ -293,8 +293,10 @@ class Operation(object):
     def __eq__(self, other):
         if isinstance(other, string_types):
             return other == str(self)
+        elif isinstance(other, Operation):
+            return vars(other) == vars(self)
         else:
-            return super(self.__class__, self).__eq__(other)
+            return NotImplemented
 
     @_makes_clone
     def with_env(self, **kwargs):

--- a/src/clom/shell.py
+++ b/src/clom/shell.py
@@ -146,8 +146,10 @@ class CommandResult(object):
     def __eq__(self, other):
         if isinstance(other, string_types):
             return other == str(self)
+        elif isinstance(other, CommandResult):
+            return vars(other) == vars(self)
         else:
-            return super(self.__class__, self).__eq__(other)
+            return NotImplemented
 
 class Shell(object):
     """

--- a/src/tests/test_clom.py
+++ b/src/tests/test_clom.py
@@ -16,7 +16,11 @@ def test_clom():
 
 
     assert '( grep \'*.pyc\' test.txt && wc && cat )' == AND(clom.grep('*.pyc', 'test.txt'), clom.wc, clom.cat)
-    assert '( grep \'*.pyc\' test.txt || wc || cat ) | wc' == OR(clom.grep('*.pyc', 'test.txt'), clom.wc, clom.cat).pipe_to(clom.wc)
+
+    bigcmd = OR(clom.grep('*.pyc', 'test.txt'), clom.wc, clom.cat).pipe_to(clom.wc)
+    assert '( grep \'*.pyc\' test.txt || wc || cat ) | wc' == bigcmd
+    assert bigcmd == bigcmd
+    assert bigcmd == OR(clom.grep('*.pyc', 'test.txt'), clom.wc, clom.cat).pipe_to(clom.wc)
 
     assert 'grep >> test.txt' == clom.grep.append_to_file('test.txt')
     assert 'grep 2>> test.txt' == clom.grep.append_to_file('test.txt', STDERR)
@@ -34,6 +38,9 @@ def test_shell():
     assert 0 == r.return_code
     assert r.return_code == r.code    
     assert str(r) == ''
+    assert r == ''
+    assert r == r
+    assert r == clom.echo.shell('')
     assert r.stdout == '\n'
 
     for i, line in enumerate(clom.echo.shell('a\nb\nc')):

--- a/src/tests/test_clom.py
+++ b/src/tests/test_clom.py
@@ -18,9 +18,11 @@ def test_clom():
     assert '( grep \'*.pyc\' test.txt && wc && cat )' == AND(clom.grep('*.pyc', 'test.txt'), clom.wc, clom.cat)
 
     bigcmd = OR(clom.grep('*.pyc', 'test.txt'), clom.wc, clom.cat).pipe_to(clom.wc)
-    assert '( grep \'*.pyc\' test.txt || wc || cat ) | wc' == bigcmd
-    assert bigcmd == bigcmd
-    assert bigcmd == OR(clom.grep('*.pyc', 'test.txt'), clom.wc, clom.cat).pipe_to(clom.wc)
+    assert (
+            '( grep \'*.pyc\' test.txt || wc || cat ) | wc' ==
+            bigcmd ==
+            OR(clom.grep('*.pyc', 'test.txt'), clom.wc, clom.cat) | clom.wc
+    )
 
     assert 'grep >> test.txt' == clom.grep.append_to_file('test.txt')
     assert 'grep 2>> test.txt' == clom.grep.append_to_file('test.txt', STDERR)
@@ -66,8 +68,14 @@ def test_piping():
     ls_pipe_echo_expected = 'ls -lah | echo monkey gorilla' 
     assert ls_pipe_echo_expected == str(ls_pipe_echo)
 
+    ls_pipe_echo = cmd_ls | cmd_echo
+    assert ls_pipe_echo_expected == str(ls_pipe_echo)
+
     ls_pipe_echo_pipe_grep = ls_pipe_echo.pipe_to(cmd_grep)
     ls_pipe_echo_pipe_grep_expected = ls_pipe_echo_expected + ' | grep monkey'
+    assert ls_pipe_echo_pipe_grep_expected == str(ls_pipe_echo_pipe_grep)
+
+    ls_pipe_echo_pipe_grep = ls_pipe_echo | cmd_grep
     assert ls_pipe_echo_pipe_grep_expected == str(ls_pipe_echo_pipe_grep)
 
 def test_new_commands():


### PR DESCRIPTION
The `__eq__` methods were broken in the case of not-string.
I fixed them in the first commit.
