### PR TITLE
simplify test running, a bit more

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ matrix:
 install:
   - pip install -r requirements.d/test.txt
 script:
-  - ./src/tests/runtests.py
+  - ./runtests

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 .PHONY: all test
 all: test
 test:
-	./src/tests/runtests.py
+	./runtests

--- a/README.rst
+++ b/README.rst
@@ -115,8 +115,8 @@ Running Tests
 
 Test are run using pytest::
 
-	pip install pytest fabfile
+	pip install pytest
 
 ::
 
-	python tests/runtests.py -v
+	./runtests -v

--- a/requirements.d/test.txt
+++ b/requirements.d/test.txt
@@ -1,3 +1,2 @@
 # the set of requirements necessary to run tests
 pytest>=2.6.3,<2.7
-fabric

--- a/runtests
+++ b/runtests
@@ -1,0 +1,1 @@
+src/tests/runtests.py

--- a/src/tests/runtests.py
+++ b/src/tests/runtests.py
@@ -3,7 +3,7 @@ import pytest
 import sys
 from os import path
 
-test_dir = path.dirname(path.abspath(__file__))
+test_dir = path.dirname(path.realpath(__file__))
 
 sys.path.insert(0, path.dirname(test_dir))
 


### PR DESCRIPTION
The tests don't actually run fab ever, so there's no need to require it.

I've made a symlink to the test-running script to make it easier to find and document.
